### PR TITLE
fix bug in the download() call, bower.config must be passed as parameter

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -53,6 +53,7 @@ module.exports = function resolver (bower) {
 
       return download(downloadUrl, downloadPath.name, bower.config).then(function (archivePatch) {
           var extractPath = tmp.dirSync();
+
           return extract(archivePatch, extractPath.name).then(function () {
               downloadPath.removeCallback();
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,9 +51,8 @@ module.exports = function resolver (bower) {
       var downloadUrl = utils.getNexusRegistry(bower.config) + pkgFragment + '-' + endpoint.target + '.tgz';
       var downloadPath = tmp.dirSync();
 
-      return download(downloadUrl, downloadPath.name, this.config).then(function (archivePatch) {
+      return download(downloadUrl, downloadPath.name, bower.config).then(function (archivePatch) {
           var extractPath = tmp.dirSync();
-
           return extract(archivePatch, extractPath.name).then(function () {
               downloadPath.removeCallback();
 


### PR DESCRIPTION
Hi,
As is said in the #3 rd opened issue, bower.config should be passed as 3rd argument of download() call
